### PR TITLE
Исправить ошибку приведения типов в RecordDreamActivity

### DIFF
--- a/app/src/main/java/com/lionido/dreams_track/activity/RecordDreamActivity.java
+++ b/app/src/main/java/com/lionido/dreams_track/activity/RecordDreamActivity.java
@@ -19,8 +19,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
+
 
 import com.google.android.material.card.MaterialCardView;
 import com.google.android.material.chip.Chip;
@@ -31,7 +30,7 @@ import com.google.android.material.textfield.TextInputEditText;
 
 import com.lionido.dreams_track.BaseActivity;
 import com.lionido.dreams_track.R;
-import com.lionido.dreams_track.adapter.SymbolsAdapter;
+
 import com.lionido.dreams_track.database.AppDatabase;
 import com.lionido.dreams_track.database.DreamDao;
 import com.lionido.dreams_track.model.Dream;
@@ -74,9 +73,8 @@ public class RecordDreamActivity extends BaseActivity {
     private TextView tvTranscript, tvEmotionIcon, tvEmotionName, tvEmotionDescription,
             tvInterpretation, tvPersonalGrowth, tvActionableAdvice;
 
-    // RecyclerView для символов
-    private RecyclerView recyclerSymbols;
-    private SymbolsAdapter symbolsAdapter;
+    // ChipGroup для символов
+    private ChipGroup chipGroupSymbols;
 
     // Утилиты
     private SpeechHelper speechHelper;
@@ -101,7 +99,7 @@ public class RecordDreamActivity extends BaseActivity {
         initializeViews();
         initializeUtils();
         setupListeners();
-        setupRecyclerView();
+        setupChipGroup();
         checkPermissions();
     }
 
@@ -140,8 +138,8 @@ public class RecordDreamActivity extends BaseActivity {
         tvPersonalGrowth = findViewById(R.id.tv_interpretation);
         tvActionableAdvice = findViewById(R.id.tv_interpretation);
 
-        // RecyclerView для символов
-        recyclerSymbols = findViewById(R.id.chip_group_symbols);
+        // ChipGroup для символов
+        chipGroupSymbols = findViewById(R.id.chip_group_symbols);
     }
 
     private void initializeUtils() {
@@ -149,10 +147,9 @@ public class RecordDreamActivity extends BaseActivity {
         openRouterAnalyzer = new OpenRouterAnalyzer(this);
     }
 
-    private void setupRecyclerView() {
-        symbolsAdapter = new SymbolsAdapter(this, new ArrayList<>());
-        recyclerSymbols.setLayoutManager(new LinearLayoutManager(this));
-        recyclerSymbols.setAdapter(symbolsAdapter);
+    private void setupChipGroup() {
+        // Инициализация ChipGroup для символов
+        // Символы будут добавляться динамически при анализе
     }
 
     private void setupListeners() {
@@ -332,7 +329,7 @@ public class RecordDreamActivity extends BaseActivity {
 
         // Показываем символы
         if (symbols != null && !symbols.isEmpty()) {
-            symbolsAdapter.updateSymbols(symbols);
+            displaySymbols(symbols);
             showCardWithAnimation(cardSymbols);
         }
 
@@ -360,6 +357,17 @@ public class RecordDreamActivity extends BaseActivity {
 
         // Активируем кнопку сохранения
         btnSave.setEnabled(true);
+    }
+
+    private void displaySymbols(List<Symbol> symbols) {
+        chipGroupSymbols.removeAllViews();
+        for (Symbol symbol : symbols) {
+            Chip chip = new Chip(this);
+            chip.setText(symbol.getName());
+            chip.setChipBackgroundColorResource(android.R.color.holo_blue_light);
+            chip.setTextColor(getResources().getColor(android.R.color.white));
+            chipGroupSymbols.addView(chip);
+        }
     }
 
     private void displayEmotion(String emotion) {


### PR DESCRIPTION
Исправлена ошибка `ClassCastException` в `RecordDreamActivity` путем замены `RecyclerView` на `ChipGroup` для отображения символов.

Ошибка возникала из-за попытки приведения `ChipGroup` к `RecyclerView` при инициализации представления `chip_group_symbols`, что приводило к сбою приложения. Изменения обеспечивают корректное использование `ChipGroup` для отображения тегов.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2e42ea0-84e8-4661-84bf-7bec388c1c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2e42ea0-84e8-4661-84bf-7bec388c1c39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

